### PR TITLE
Replace `getDatabase()` calls

### DIFF
--- a/src/DependencyInjection/MetaModelsAttributeTranslatedSelectExtension.php
+++ b/src/DependencyInjection/MetaModelsAttributeTranslatedSelectExtension.php
@@ -12,6 +12,7 @@
  *
  * @package    MetaModels/attribute_translatedselect
  * @author     David Molineus <david.molineus@netzmacht.de>
+ * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
  * @copyright  2012-2019 The MetaModels team.
  * @license    https://github.com/MetaModels/attribute_translatedselect/blob/master/LICENSE LGPL-3.0-or-later
  * @filesource
@@ -26,6 +27,8 @@ use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 
 /**
  * This is the Bundle extension.
+ *
+ * @SuppressWarnings(PHPMD.LongClassName)
  */
 class MetaModelsAttributeTranslatedSelectExtension extends Extension
 {

--- a/src/MetaModelsAttributeTranslatedSelectBundle.php
+++ b/src/MetaModelsAttributeTranslatedSelectBundle.php
@@ -12,6 +12,7 @@
  *
  * @package    MetaModels/attribute_translatedselect
  * @author     David Molineus <david.molineus@netzmacht.de>
+ * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
  * @copyright  2012-2019 The MetaModels team.
  * @license    https://github.com/MetaModels/attribute_translatedselect/blob/master/LICENSE LGPL-3.0-or-later
  * @filesource
@@ -23,8 +24,9 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
  * The Bundle class.
+ *
+ * @SuppressWarnings(PHPMD.LongClassName)
  */
 class MetaModelsAttributeTranslatedSelectBundle extends Bundle
 {
-
 }

--- a/tests/Attribute/TranslatedSelectAttributeTypeFactoryTest.php
+++ b/tests/Attribute/TranslatedSelectAttributeTypeFactoryTest.php
@@ -28,6 +28,8 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * Test the attribute factory.
+ *
+ * @covers \MetaModels\AttributeTranslatedSelectBundle\Attribute\AttributeTypeFactory
  */
 class TranslatedSelectAttributeTypeFactoryTest extends TestCase
 {

--- a/tests/Attribute/TranslatedSelectTest.php
+++ b/tests/Attribute/TranslatedSelectTest.php
@@ -27,6 +27,8 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests to test class Select.
+ *
+ * @covers \MetaModels\AttributeTranslatedSelectBundle\Attribute\TranslatedSelect
  */
 class TranslatedSelectTest extends TestCase
 {


### PR DESCRIPTION
This fixes #23 by removing the failing `getDatabase()` calls and replacing them with doctrine connection usage.
